### PR TITLE
add -nogui for JLinkGDBServer options

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ replace `board-hifive1-revb` with `board-hifive1`.
 3. Run the programmer software.
   * HiFive1 Rev B:
 ```sh
-/path/to/JLinkGDBServer -device FE310 -if JTAG -speed 4000 -port 3333
+/path/to/JLinkGDBServer -device FE310 -if JTAG -speed 4000 -port 3333 -nogui
 ```
   * HiFive1:
 ```sh


### PR DESCRIPTION
The new JLink software defaults to showing a rather distracting GUI window on each upload and other operations.

There's a new `-nogui` option which should be used with these examples.