### PR TITLE
Added small dependency note to README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ $ rustup target add riscv32imac-unknown-none-elf
 the long version, which additionally covers flashing, running and debugging
 programs, check [the embedded Rust book](https://rust-embedded.github.io/book).
 
+
+**NOTE**: If you don't have cargo generate install use,
+
+    cargo install cargo-generate
+
+To install it. 
+
+
 1. Instantiate the template.
 
 ``` console

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ the long version, which additionally covers flashing, running and debugging
 programs, check [the embedded Rust book](https://rust-embedded.github.io/book).
 
 
-**NOTE**: If you don't have cargo generate install use,
+**NOTE**: If you don't have `cargo generate` installed, use
 
     cargo install cargo-generate
 
-To install it. 
+to install it. 
 
 
 1. Instantiate the template.


### PR DESCRIPTION
I am not much of a rust user so I needed to install this and it wasn't in this documentation. By providing this, it saves developers just a few moments figuring out how to install `cargo generate`