### PR TITLE
Fix: Updated broken wifi example

### DIFF
--- a/examples/spi_wifi.rs
+++ b/examples/spi_wifi.rs
@@ -119,7 +119,7 @@ fn main() -> ! {
     let gpio = dr.pins;
 
     // Configure clocks
-    let clocks = hifive1::clock::configure(p.PRCI, p.AONCLK, 50.mhz().into());
+    let clocks = hifive1::clock::configure(p.PRCI, p.AONCLK, 320.mhz().into());
 
     // Configure UART for stdout
     hifive1::stdout::configure(p.UART0, pin!(gpio, uart0_tx), pin!(gpio, uart0_rx), 115_200.bps(), clocks);


### PR DESCRIPTION
Fixes #12, where the wifi example has timing issues when the board has communication issues with the wifi chip when clocked at 80MHz, so we change the example to 320MHz where these issues disappear.