### PR TITLE
fix warnings and lint

### DIFF
--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -3,10 +3,10 @@
 
 extern crate panic_halt;
 
-use riscv_rt::entry;
 use hifive1::hal::prelude::*;
 use hifive1::hal::DeviceResources;
-use hifive1::{sprintln, pin};
+use hifive1::{pin, sprintln};
+use riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {
@@ -18,7 +18,13 @@ fn main() -> ! {
     let clocks = hifive1::clock::configure(p.PRCI, p.AONCLK, 320.mhz().into());
 
     // Configure UART for stdout
-    hifive1::stdout::configure(p.UART0, pin!(pins, uart0_tx), pin!(pins, uart0_rx), 115_200.bps(), clocks);
+    hifive1::stdout::configure(
+        p.UART0,
+        pin!(pins, uart0_tx),
+        pin!(pins, uart0_rx),
+        115_200.bps(),
+        clocks,
+    );
 
     sprintln!("hello world!");
 

--- a/examples/i2c.rs
+++ b/examples/i2c.rs
@@ -3,12 +3,11 @@
 
 extern crate panic_halt;
 
-use riscv_rt::entry;
+use hifive1::hal::i2c::{I2c, Speed};
 use hifive1::hal::prelude::*;
-use hifive1::hal::i2c::{Speed, I2c};
 use hifive1::hal::DeviceResources;
-use hifive1::{sprintln, pin};
-
+use hifive1::{pin, sprintln};
+use riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {
@@ -20,7 +19,13 @@ fn main() -> ! {
     let clocks = hifive1::clock::configure(p.PRCI, p.AONCLK, 100.mhz().into());
 
     // Configure UART for stdout
-    hifive1::stdout::configure(p.UART0, pin!(pins, uart0_tx), pin!(pins, uart0_rx), 115_200.bps(), clocks);
+    hifive1::stdout::configure(
+        p.UART0,
+        pin!(pins, uart0_tx),
+        pin!(pins, uart0_rx),
+        115_200.bps(),
+        clocks,
+    );
 
     // Configure I2C
     let sda = pin!(pins, i2c0_sda).into_iof0();
@@ -35,5 +40,5 @@ fn main() -> ! {
         Err(e) => sprintln!("Error: {:?}", e),
     }
 
-    loop { }
+    loop {}
 }

--- a/examples/led_gpio.rs
+++ b/examples/led_gpio.rs
@@ -10,11 +10,11 @@
 
 extern crate panic_halt;
 
-use riscv_rt::entry;
-use hifive1::hal::prelude::*;
 use hifive1::hal::delay::Sleep;
+use hifive1::hal::prelude::*;
 use hifive1::hal::DeviceResources;
 use hifive1::pin;
+use riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {
@@ -37,7 +37,7 @@ fn main() -> ! {
     const PERIOD: u32 = 1000; // 1s
     loop {
         eled.toggle().unwrap();
-        
+
         // sleep for 1s
         sleep.delay_ms(PERIOD);
     }

--- a/examples/leds_blink.rs
+++ b/examples/leds_blink.rs
@@ -8,15 +8,15 @@
 
 extern crate panic_halt;
 
-use riscv_rt::entry;
-use hifive1::hal::prelude::*;
 use hifive1::hal::delay::Sleep;
+use hifive1::hal::prelude::*;
 use hifive1::hal::DeviceResources;
-use hifive1::{Led, pin, pins};
 use hifive1::sprintln;
+use hifive1::{pin, pins, Led};
+use riscv_rt::entry;
 
 // switches led according to supplied status returning the new state back
-fn toggle_led(led: &mut Led, status: bool) -> bool {
+fn toggle_led(led: &mut dyn Led, status: bool) -> bool {
     match status {
         true => led.on(),
         false => led.off(),
@@ -35,14 +35,20 @@ fn main() -> ! {
     let clocks = hifive1::clock::configure(p.PRCI, p.AONCLK, 320.mhz().into());
 
     // Configure UART for stdout
-    hifive1::stdout::configure(p.UART0, pin!(pins, uart0_tx), pin!(pins, uart0_rx), 115_200.bps(), clocks);
+    hifive1::stdout::configure(
+        p.UART0,
+        pin!(pins, uart0_tx),
+        pin!(pins, uart0_rx),
+        115_200.bps(),
+        clocks,
+    );
 
     // get all 3 led pins in a tuple (each pin is it's own type here)
     let rgb_pins = pins!(pins, (led_red, led_green, led_blue));
     let mut tleds = hifive1::rgb(rgb_pins.0, rgb_pins.1, rgb_pins.2);
 
     // get leds as the Led trait in an array so we can index them
-    let ileds: [&mut Led; 3] = [&mut tleds.0, &mut tleds.1, &mut tleds.2];
+    let ileds: [&mut dyn Led; 3] = [&mut tleds.0, &mut tleds.1, &mut tleds.2];
 
     // get the local interrupts struct
     let clint = dr.core_peripherals.clint;

--- a/examples/pll.rs
+++ b/examples/pll.rs
@@ -3,10 +3,10 @@
 
 extern crate panic_halt;
 
-use riscv_rt::entry;
 use hifive1::hal::prelude::*;
 use hifive1::hal::DeviceResources;
-use hifive1::{sprintln, pin};
+use hifive1::{pin, sprintln};
+use riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {
@@ -18,12 +18,22 @@ fn main() -> ! {
     let clocks = hifive1::clock::configure(p.PRCI, p.AONCLK, 320.mhz().into());
 
     // Configure UART for stdout
-    hifive1::stdout::configure(p.UART0, pin!(pins, uart0_tx), pin!(pins, uart0_rx), 115_200.bps(), clocks);
+    hifive1::stdout::configure(
+        p.UART0,
+        pin!(pins, uart0_tx),
+        pin!(pins, uart0_rx),
+        115_200.bps(),
+        clocks,
+    );
 
-    sprintln!("Measured clock frequency of {}MHz",
-             clocks.measure_coreclk().0 / 1_000_000);
-    sprintln!("Computed clock frequency of {}MHz",
-             clocks.coreclk().0 / 1_000_000);
+    sprintln!(
+        "Measured clock frequency of {}MHz",
+        clocks.measure_coreclk().0 / 1_000_000
+    );
+    sprintln!(
+        "Computed clock frequency of {}MHz",
+        clocks.coreclk().0 / 1_000_000
+    );
 
     loop {}
 }

--- a/examples/spi.rs
+++ b/examples/spi.rs
@@ -3,11 +3,11 @@
 
 extern crate panic_halt;
 
-use riscv_rt::entry;
 use hifive1::hal::prelude::*;
 use hifive1::hal::spi::{Spi, MODE_0};
 use hifive1::hal::DeviceResources;
 use hifive1::pin;
+use riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/examples/spi_wifi.rs
+++ b/examples/spi_wifi.rs
@@ -3,17 +3,17 @@
 
 //extern crate panic_halt;
 
-use riscv_rt::entry;
-use hifive1::hal::prelude::*;
-use hifive1::hal::spi::{Spi, MODE_0, SpiX};
-use hifive1::hal::gpio::{gpio0::{Pin9, Pin10}, Output, Regular, Invert, Input, Floating};
-use hifive1::hal::delay::Delay;
-use hifive1::hal::clock::Clocks;
-use hifive1::hal::DeviceResources;
-use hifive1::{sprintln, pin};
 use core::panic::PanicInfo;
 use embedded_hal::blocking::delay::DelayUs;
 use embedded_hal::blocking::spi::WriteIter;
+use hifive1::hal::clock::Clocks;
+use hifive1::hal::delay::Delay;
+use hifive1::hal::gpio::{gpio0::Pin10, Floating, Input};
+use hifive1::hal::prelude::*;
+use hifive1::hal::spi::{Spi, SpiX, MODE_0};
+use hifive1::hal::DeviceResources;
+use hifive1::{pin, sprintln};
+use riscv_rt::entry;
 
 #[inline(never)]
 #[panic_handler]
@@ -30,7 +30,7 @@ fn panic(info: &PanicInfo) -> ! {
 enum EspError {
     ProtocolError,
     BufferOverflow,
-    WouldBlock
+    WouldBlock,
 }
 
 struct EspWiFi<SPI, PINS> {
@@ -122,7 +122,13 @@ fn main() -> ! {
     let clocks = hifive1::clock::configure(p.PRCI, p.AONCLK, 320.mhz().into());
 
     // Configure UART for stdout
-    hifive1::stdout::configure(p.UART0, pin!(gpio, uart0_tx), pin!(gpio, uart0_rx), 115_200.bps(), clocks);
+    hifive1::stdout::configure(
+        p.UART0,
+        pin!(gpio, uart0_tx),
+        pin!(gpio, uart0_rx),
+        115_200.bps(),
+        clocks,
+    );
 
     // Configure SPI pins
     let mosi = pin!(gpio, spi0_mosi).into_iof0();

--- a/examples/spi_writeonly.rs
+++ b/examples/spi_writeonly.rs
@@ -3,11 +3,11 @@
 
 extern crate panic_halt;
 
-use riscv_rt::entry;
 use hifive1::hal::prelude::*;
 use hifive1::hal::spi::{Spi, MODE_0};
 use hifive1::hal::DeviceResources;
 use hifive1::pin;
+use riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,9 +3,9 @@
 
 extern crate panic_halt;
 
-use riscv_rt::entry;
 use hifive1::hal::prelude::*;
 use hifive1::hal::DeviceResources;
+use riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {


### PR DESCRIPTION
Fixes warnings for missing `dyn Trait` and unused `import` statements, re-formats with cargo fmt