### PR TITLE
Update riscv-rt to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ embedded-hal = "0.2.7"
 hifive1 = { version = "0.10.0", features = ["board-hifive1-revb"] }
 panic-halt = "0.2.0"
 riscv = "0.10.0"
-riscv-rt = "0.10.0"
+riscv-rt = "0.11.0"
 
 # this lets you use `cargo fix`!
 [[bin]]


### PR DESCRIPTION
riscv-rt 0.10 got yanked. Hence, using this version does no longer work.